### PR TITLE
Fix mixed content error by making urls https

### DIFF
--- a/js/starwars.js
+++ b/js/starwars.js
@@ -317,6 +317,8 @@ async function newPerson() {
       speciesName = species.data.name;
    }
 
+   // NEED TO FIX THE CORS ERROR - the species and homeworld URLs are http not https
+
    // Populate the the heading
    thing.textContent = "Person";
    thingNumber.textContent = randomPerson;

--- a/js/starwars.js
+++ b/js/starwars.js
@@ -27,6 +27,12 @@ function resErrOrParse(response) {
    }
    return response.json();
 }
+// Function to modify URLs to HTTPS and fix mixed content error
+function fixMixed(url) {
+   const arr = url.split("");
+   arr.splice(4, 0, "s");
+   return arr.join("");
+}
 
 let count = 0;
 let page = 1;
@@ -286,16 +292,14 @@ async function newPerson() {
    count = people.data.count;
    // and pick a random person
    randomPerson = Math.floor(Math.random() * count) + 1;
-   console.log("-/-/-/-/-/-/-/-/-/-/-/-/-/-/-/-/-/-/");
-   console.log(
-      `Display details for person number ${randomPerson} out of ${count} people`
-   );
+   console.log("-/-/-/-/-/-/-/-/-");
+   console.log(`Display person ${randomPerson} out of ${count}`);
    index = randomPerson % 10 === 0 ? 9 : (randomPerson % 10) - 1;
    page =
       index === 9
          ? randomPerson / 10
          : (randomPerson - (randomPerson % 10)) / 10 + 1;
-   console.log(`Person data is on page ${page} at index number ${index}`);
+   console.log(`Data on page ${page} / index ${index}`);
    // Load the person data
    const findPerson = await axios.get(
       `https://swapi.dev/api/people/?page=${page}`
@@ -305,20 +309,17 @@ async function newPerson() {
    // Load the homeworld name
    let homeName;
    if (aPerson.homeworld) {
-      const home = await axios.get(aPerson.homeworld);
-      console.log(home);
+      const newURL = fixMixed(aPerson.homeworld);
+      const home = await axios.get(newURL);
       homeName = home.data.name;
    }
    // Load the species name
    let speciesName;
    if (aPerson.species[0]) {
-      const species = await axios.get(aPerson.species[0]);
-      console.log(species);
+      const newURL = fixMixed(aPerson.species[0]);
+      const species = await axios.get(newURL);
       speciesName = species.data.name;
    }
-
-   // NEED TO FIX THE CORS ERROR - the species and homeworld URLs are http not https
-
    // Populate the the heading
    thing.textContent = "Person";
    thingNumber.textContent = randomPerson;
@@ -330,7 +331,7 @@ async function newPerson() {
    // populate the results table
    // ONE
    headingOne.textContent = "Name: ";
-   valueOne.textContent = `${aPerson.name}`;
+   valueOne.textContent = aPerson.name;
    // TWO
    headingTwo.textContent = "Homeworld: ";
    valueTwo.textContent = homeName;
@@ -339,22 +340,22 @@ async function newPerson() {
    valueThree.textContent = speciesName;
    // FOUR
    headingFour.textContent = "Birth Year: ";
-   valueFour.textContent = `${aPerson.birth_year}`;
+   valueFour.textContent = aPerson.birth_year;
    // FIVE
    headingFive.textContent = "Mass: ";
    valueFive.textContent = `${aPerson.mass} kg`;
    // SIX
    headingSix.textContent = "Gender: ";
-   valueSix.textContent = `${aPerson.gender}`;
+   valueSix.textContent = aPerson.gender;
    // SEVEN
    headingSeven.textContent = "Hair Colour: ";
-   valueSeven.textContent = `${aPerson.hair_color}`;
+   valueSeven.textContent = aPerson.hair_color;
    // EIGHT
    headingEight.textContent = "Skin Colour: ";
-   valueEight.textContent = `${aPerson.skin_color}`;
+   valueEight.textContent = aPerson.skin_color;
    // NINE
    headingNine.textContent = "Eye Colour: ";
-   valueNine.textContent = `${aPerson.eye_color}`;
+   valueNine.textContent = aPerson.eye_color;
    resultsSection.classList.remove("thinking");
 }
 


### PR DESCRIPTION
In the 'people' category there are 2 extra requests to retrieve homeworld and species names from URLs listed in the person. The URLs are http (not https) and were causing a mixed content error. This update fixes the error by making the them https